### PR TITLE
update typescript to v4.2.4 to be compatible with typedoc v0.20.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",
-    "@typescript-eslint/eslint-plugin": "^4.20.0",
-    "@typescript-eslint/parser": "^4.20.0",
+    "@typescript-eslint/eslint-plugin": "^4.33.0",
+    "@typescript-eslint/parser": "^4.33.0",
     "eslint": "^7.23.0",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.4",
     "typedoc": "^0.20.35",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.4"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
update typescript to v4.2.4 to be compatible with typedoc v0.20.35 as it failed during the CI. 